### PR TITLE
Add Account Settings links

### DIFF
--- a/src/components/nav/AuthSection.tsx
+++ b/src/components/nav/AuthSection.tsx
@@ -50,6 +50,12 @@ export const AuthSection = () => {
                 Profile Settings
               </Link>
             </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to="/account-settings" className="flex items-center">
+                <Settings size={16} className="mr-2" />
+                Account Settings
+              </Link>
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleSignOut}>
               <LogOut size={16} className="mr-2" />

--- a/src/components/nav/MobileNav.tsx
+++ b/src/components/nav/MobileNav.tsx
@@ -34,9 +34,9 @@ export const MobileNav: React.FC<MobileNavProps> = ({ isOpen, onLinkClick }) => 
         {user ? (
           <div className="border-t pt-4 space-y-2">
             <p className="text-sm text-muted-foreground">{user.email}</p>
-            <Button 
+            <Button
               asChild
-              variant="outline" 
+              variant="outline"
               className="w-full justify-start"
             >
               <Link to="/profile" onClick={onLinkClick}>
@@ -44,8 +44,14 @@ export const MobileNav: React.FC<MobileNavProps> = ({ isOpen, onLinkClick }) => 
                 Profile Settings
               </Link>
             </Button>
-            <Button 
-              variant="outline" 
+            <Button asChild variant="outline" className="w-full justify-start">
+              <Link to="/account-settings" onClick={onLinkClick}>
+                <Settings size={16} className="mr-2" />
+                Account Settings
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
               onClick={handleSignOut}
               className="w-full justify-start"
             >


### PR DESCRIPTION
## Summary
- add Account Settings item to desktop user dropdown
- expose Account Settings button in mobile nav

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868f9809de0832e9b361e6af0c6b42f